### PR TITLE
Fix timezone handling for invoice due date

### DIFF
--- a/api/src/common/services/pdf.service.ts
+++ b/api/src/common/services/pdf.service.ts
@@ -54,6 +54,7 @@ export class PdfService {
           year: 'numeric',
           month: '2-digit',
           day: '2-digit',
+          timeZone: 'Asia/Tokyo',
         }),
         AMOUNT_YEN: this.formatYenCurrency(data.amount),
         AMOUNT_YEN_IN_TABLE: this.formatYenCurrency(data.amount),
@@ -65,6 +66,7 @@ export class PdfService {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',
+            timeZone: 'Asia/Tokyo',
           }),
         ITEM_DESCRIPTION_TEXT: data.itemDescriptionText || '',
       };

--- a/web/src/app/invoices/new/page.tsx
+++ b/web/src/app/invoices/new/page.tsx
@@ -64,8 +64,9 @@ export default function CreateInvoicePage() {
         partnerName: values.partnerName,
         description: values.description,
         amount: values.amount,
-        issueDate: values.issueDate.toISOString(),
-        dueDate: values.dueDate.toISOString(),
+        // Use date-only strings to avoid timezone issues
+        issueDate: format(values.issueDate, 'yyyy-MM-dd'),
+        dueDate: format(values.dueDate, 'yyyy-MM-dd'),
       });
 
       if (result && result.id) {


### PR DESCRIPTION
## Summary
- ensure invoice form sends date-only strings
- set explicit Asia/Tokyo timezone when formatting PDF dates

## Testing
- `pnpm test` *(fails: Your test suite must contain at least one test)*
- `pnpm lint` in `web`
- `pnpm lint` in `api` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842f2faf8148328a98d0e64d8aabc76