### PR TITLE
Localize UI to Japanese

### DIFF
--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -33,8 +33,8 @@ const displayAccountCategory = (category: AccountCategory) => {
 export default function AccountsPage() {
   const { accounts, loading, error } = useGetAccounts();
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error loading accounts: {error.message}</p>;
+  if (loading) return <p>読み込み中...</p>;
+  if (error) return <p>勘定科目の読み込みエラー: {error.message}</p>;
 
   return (
     <div className="container mx-auto py-10">

--- a/web/src/app/expenses/[id]/edit/page.tsx
+++ b/web/src/app/expenses/[id]/edit/page.tsx
@@ -268,24 +268,24 @@ export default function EditExpenseRequestPage() {
   } else if (loadError) {
     content = (
       <Alert variant="destructive">
-        <AlertTitle>Error Loading Expense</AlertTitle>
+        <AlertTitle>経費情報の読み込みエラー</AlertTitle>
         <AlertDescription>{loadError.message}</AlertDescription>
       </Alert>
     );
   } else if (notFound) {
     content = (
       <Alert>
-        <AlertTitle>Not Found</AlertTitle>
-        <AlertDescription>Expense request not found.</AlertDescription>
+        <AlertTitle>見つかりません</AlertTitle>
+        <AlertDescription>経費申請が見つかりません。</AlertDescription>
       </Alert>
     );
   } else if (notRejected) {
     content = (
       <>
         <Alert>
-          <AlertTitle>Cannot Edit</AlertTitle>
+          <AlertTitle>編集できません</AlertTitle>
           <AlertDescription>
-            Only rejected expense requests can be edited. Current status: {expenseData!.state}
+            差戻し状態の経費申請のみ編集可能です。現在のステータス: {expenseData!.state}
           </AlertDescription>
         </Alert>
         <Button onClick={() => router.back()} className="mt-4">戻る</Button>

--- a/web/src/app/expenses/[id]/page.tsx
+++ b/web/src/app/expenses/[id]/page.tsx
@@ -78,12 +78,12 @@ export default function ExpenseDetailPage() {
     );
   }
 
-  if (loading) return <div className="container mx-auto p-4">Loading expense details...</div>;
+  if (loading) return <div className="container mx-auto p-4">経費詳細を読み込み中...</div>;
   if (error) {
     return (
       <div className="container mx-auto p-4">
         <Alert variant="destructive">
-          <AlertTitle>Error Loading Expense</AlertTitle>
+          <AlertTitle>経費情報の読み込みエラー</AlertTitle>
           <AlertDescription>{error.message}</AlertDescription>
         </Alert>
       </div>
@@ -94,8 +94,8 @@ export default function ExpenseDetailPage() {
     return (
       <div className="container mx-auto p-4">
         <Alert>
-          <AlertTitle>Not Found</AlertTitle>
-          <AlertDescription>Expense request not found.</AlertDescription>
+          <AlertTitle>見つかりません</AlertTitle>
+          <AlertDescription>経費申請が見つかりません。</AlertDescription>
         </Alert>
       </div>
     );
@@ -108,18 +108,18 @@ export default function ExpenseDetailPage() {
       <Toaster position="top-center" />
       <Card>
         <CardHeader>
-          <CardTitle>Expense Request Details</CardTitle>
-          <CardDescription>Viewing expense ID: {id}</CardDescription>
+          <CardTitle>経費申請詳細</CardTitle>
+          <CardDescription>申請ID: {id} の内容</CardDescription>
         </CardHeader>
         <CardContent>
           <Table>
             <TableBody>
               <TableRow>
-                <TableCell className="font-medium">Amount</TableCell>
+                <TableCell className="font-medium">金額</TableCell>
                 <TableCell>{amount.toLocaleString()}</TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-medium">State</TableCell>
+                <TableCell className="font-medium">状態</TableCell>
                 <TableCell>
                   <Badge variant={getStateBadgeVariant(state)}>
                     {state}
@@ -127,22 +127,22 @@ export default function ExpenseDetailPage() {
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-medium">Created At</TableCell>
+                <TableCell className="font-medium">申請日</TableCell>
                 <TableCell>{new Date(createdAt).toLocaleString()}</TableCell>
               </TableRow>
               {approvedAt && (
                 <TableRow>
-                  <TableCell className="font-medium">Approved At</TableCell>
+                  <TableCell className="font-medium">承認日</TableCell>
                   <TableCell>{new Date(approvedAt).toLocaleString()}</TableCell>
                 </TableRow>
               )}
               <TableRow>
-                <TableCell className="font-medium">Requester</TableCell>
+                <TableCell className="font-medium">申請者</TableCell>
                 <TableCell>{requester.username} (ID: {requester.id})</TableCell>
               </TableRow>
               {approver && (
                 <TableRow>
-                  <TableCell className="font-medium">Approver</TableCell>
+                  <TableCell className="font-medium">承認者</TableCell>
                   <TableCell>{approver.username} (ID: {approver.id})</TableCell>
                 </TableRow>
               )}
@@ -154,38 +154,38 @@ export default function ExpenseDetailPage() {
       {attachment && (
         <Card>
           <CardHeader>
-            <CardTitle>Attachment Details</CardTitle>
+            <CardTitle>添付ファイル詳細</CardTitle>
           </CardHeader>
           <CardContent>
             <Table>
               <TableBody>
                 <TableRow>
-                  <TableCell className="font-medium">Title</TableCell>
+                  <TableCell className="font-medium">タイトル</TableCell>
                   <TableCell>{attachment.title}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="font-medium">S3 Key</TableCell>
+                  <TableCell className="font-medium">S3キー</TableCell>
                   <TableCell>{attachment.s3Key}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="font-medium">Attachment Amount</TableCell>
+                  <TableCell className="font-medium">添付金額</TableCell>
                   <TableCell>{attachment.amount.toLocaleString()}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="font-medium">File</TableCell>
+                  <TableCell className="font-medium">ファイル</TableCell>
                   <TableCell>
-                    {fetchingPresignedUrl && <p>Loading link...</p>}
-                    {presignedUrlError && <p className="text-red-500">Error: {presignedUrlError.message}</p>}
+                    {fetchingPresignedUrl && <p>リンクを生成中...</p>}
+                    {presignedUrlError && <p className="text-red-500">エラー: {presignedUrlError.message}</p>}
                     {presignedUrlData?.url && (
                       <Button asChild variant="link">
                         <Link href={presignedUrlData.url} target="_blank" rel="noopener noreferrer">
-                          View/Download Attachment
+                          添付を表示/ダウンロード
                         </Link>
                       </Button>
                     )}
                     {!presignedUrlData?.url && !fetchingPresignedUrl && (
                       <Button onClick={refetchPresignedUrl} variant="outline" size="sm">
-                        Generate Link
+                        リンクを生成
                       </Button>
                     )}
                   </TableCell>
@@ -198,40 +198,40 @@ export default function ExpenseDetailPage() {
 
       {payment && (
         <Card>
-          <CardHeader><CardTitle>Payment Details</CardTitle></CardHeader>
+          <CardHeader><CardTitle>支払詳細</CardTitle></CardHeader>
           <CardContent>
             <Table>
               <TableBody>
                 <TableRow>
-                  <TableCell className="font-medium">Payment ID</TableCell>
+                  <TableCell className="font-medium">支払ID</TableCell>
                   <TableCell>{payment.id}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="font-medium">Payment Amount</TableCell>
+                  <TableCell className="font-medium">支払金額</TableCell>
                   <TableCell>{payment.amount.toLocaleString()}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell className="font-medium">Paid At</TableCell>
+                  <TableCell className="font-medium">支払日</TableCell>
                   <TableCell>{new Date(payment.paidAt).toLocaleString()}</TableCell>
                 </TableRow>
                 {payment.direction && (
                     <TableRow>
-                        <TableCell className="font-medium">Direction</TableCell>
+                        <TableCell className="font-medium">区分</TableCell>
                         <TableCell>{payment.direction}</TableCell>
                     </TableRow>
                 )}
                 {payment.method && (
                     <TableRow>
-                        <TableCell className="font-medium">Method</TableCell>
+                        <TableCell className="font-medium">方法</TableCell>
                         <TableCell>{payment.method}</TableCell>
                     </TableRow>
                 )}
               </TableBody>
             </Table>
-            {/* Display Payment Attachments if any */}
+            {/* 支払添付ファイル */}
             {payment.attachments && payment.attachments.length > 0 && (
               <div className="mt-6">
-                <h4 className="text-lg font-semibold mb-3">Payment Attachments:</h4>
+                <h4 className="text-lg font-semibold mb-3">支払添付ファイル:</h4>
                 <div className="space-y-4">
                   {payment.attachments.map((actualAttachment) => {
                     if (!actualAttachment) return null;
@@ -239,7 +239,7 @@ export default function ExpenseDetailPage() {
                       <Card key={actualAttachment.id} className="p-4">
                         <p className="font-medium text-base">{actualAttachment.title}</p>
                         {actualAttachment.amount != null && (
-                            <p className="text-sm text-muted-foreground">Amount: {actualAttachment.amount.toLocaleString()}</p>
+                            <p className="text-sm text-muted-foreground">金額: {actualAttachment.amount.toLocaleString()}</p>
                         )}
                         <PaymentAttachmentLinkRenderer s3Key={actualAttachment.s3Key} title={actualAttachment.title} />
                       </Card>
@@ -257,7 +257,7 @@ export default function ExpenseDetailPage() {
           {/* DRAFT状態: 申請提出ボタン */}
           {state === 'DRAFT' && (
             <Button variant="default">
-              Submit Request
+              申請提出
             </Button>
           )}
           
@@ -265,10 +265,10 @@ export default function ExpenseDetailPage() {
           {state === 'PENDING' && (
             <>
               <Button variant="default">
-                Approve
+                承認
               </Button>
               <Button variant="destructive">
-                Reject
+                差戻し
               </Button>
             </>
           )}
@@ -276,14 +276,14 @@ export default function ExpenseDetailPage() {
           {/* APPROVED状態: 支払いボタン */}
           {state === 'APPROVED' && (
             <Button asChild variant="default">
-              <Link href={`/expenses/${id}/pay`}>Pay Expense</Link>
+              <Link href={`/expenses/${id}/pay`}>支払処理</Link>
             </Button>
           )}
           
           {/* PAID状態: クローズボタン */}
           {state === 'PAID' && (
             <Button variant="outline">
-              Close Request
+              完了にする
             </Button>
           )}
           
@@ -291,14 +291,14 @@ export default function ExpenseDetailPage() {
           {state === 'REJECTED' && (
             <>
               <Button asChild variant="default">
-                <Link href={`/expenses/${id}/edit`}>Edit Expense</Link>
+                <Link href={`/expenses/${id}/edit`}>経費を編集</Link>
               </Button>
               <Button 
                 onClick={handleResubmit} 
                 disabled={isResubmitting}
                 variant="outline"
               >
-                {isResubmitting ? 'Resubmitting...' : 'Resubmit'}
+                {isResubmitting ? '再申請中...' : '再申請'}
               </Button>
             </>
           )}
@@ -306,7 +306,7 @@ export default function ExpenseDetailPage() {
           {/* CLOSED状態: アクションなし（最終状態） */}
         </div>
         <Button variant="outline" asChild>
-          <Link href="/expenses">Back to Expenses List</Link>
+          <Link href="/expenses">一覧へ戻る</Link>
         </Button>
       </div>
       <Toaster />

--- a/web/src/app/expenses/[id]/pay/page.tsx
+++ b/web/src/app/expenses/[id]/pay/page.tsx
@@ -125,9 +125,9 @@ export default function PayExpensePage() {
     }
   }, [paymentErrorState]);
 
-  if (expenseLoading || !numericId) return <div className="container mx-auto p-4">Loading...</div>;
-  if (expenseError) return <div className="container mx-auto p-4">Error loading expense: {expenseError.message}</div>;
-  if (!expenseData) return <div className="container mx-auto p-4">Expense not found.</div>;
+  if (expenseLoading || !numericId) return <div className="container mx-auto p-4">読み込み中...</div>;
+  if (expenseError) return <div className="container mx-auto p-4">経費情報の読み込みエラー: {expenseError.message}</div>;
+  if (!expenseData) return <div className="container mx-auto p-4">経費申請が見つかりません。</div>;
 
   // Prevent payment if not APPROVED, with specific messages for other states
   if (expenseData.state !== 'APPROVED') {

--- a/web/src/app/expenses/new/page.tsx
+++ b/web/src/app/expenses/new/page.tsx
@@ -104,12 +104,12 @@ export default function NewExpenseRequestPage() {
               const errorText = await s3Response.text();
               throw new Error(`S3 Upload Failed: ${s3Response.status} ${errorText}`);
             }
-            return "File uploaded to S3!";
+            return "S3へのアップロード完了";
           }),
           {
-            loading: 'Uploading attachment to S3...',
+            loading: '添付ファイルをS3にアップロード中...',
             success: (message) => message,
-            error: (err) => `Attachment S3 upload failed: ${err.message}`,
+            error: (err) => `S3アップロード失敗: ${err.message}`,
           }
         );
 
@@ -128,12 +128,12 @@ export default function NewExpenseRequestPage() {
               throw new Error('Attachment ID not found after DB save.');
             }
             finalAttachmentId = dbRes.id;
-            return "Attachment metadata saved!";
+            return "添付情報を保存しました";
           }),
           {
-            loading: 'Saving attachment details...',
+            loading: '添付情報を保存中...',
             success: (message) => message,
-            error: (err) => `Saving attachment failed: ${err.message}`,
+            error: (err) => `添付情報の保存に失敗: ${err.message}`,
           }
         );
       }
@@ -160,12 +160,12 @@ export default function NewExpenseRequestPage() {
           setSelectedFile(null);
           // router.push('/expenses'); // Or to the detail page: /expenses/${res.data.submitExpenseRequest.id}
           router.push('/expenses'); // Placeholder redirect
-          return 'Expense request created successfully!';
+          return '経費申請が作成されました';
         }),
         {
-          loading: 'Submitting expense request...',
+          loading: '経費申請を送信中...',
           success: (message) => message,
-          error: (err) => `Submission failed: ${err.message}`,
+          error: (err) => `送信に失敗しました: ${err.message}`,
         }
       );
 
@@ -290,12 +290,12 @@ export default function NewExpenseRequestPage() {
             <FormControl>
               <Input type="file" onChange={handleFileChange} accept=".pdf,.jpg,.jpeg,.png" />
             </FormControl>
-            {selectedFile && <FormDescription>Selected file: {selectedFile.name}</FormDescription>}
+            {selectedFile && <FormDescription>選択されたファイル: {selectedFile.name}</FormDescription>}
             <FormMessage />
           </FormItem>
 
           <Button type="submit" disabled={isSubmitting || accountsLoading} className="w-full md:w-auto">
-            {isSubmitting ? 'Submitting...' : 'Submit Expense Request'}
+            {isSubmitting ? '送信中...' : '経費申請を送信'}
           </Button>
         </form>
       </Form>

--- a/web/src/app/expenses/page.tsx
+++ b/web/src/app/expenses/page.tsx
@@ -51,7 +51,7 @@ const AdminExpensesPage = () => {
 
   useEffect(() => {
     if (error) {
-      toast.error(`Error fetching expenses: ${error.message}`);
+      toast.error(`経費データの取得に失敗しました: ${error.message}`);
     }
   }, [error]);
 

--- a/web/src/app/invoices/[id]/pay/page.tsx
+++ b/web/src/app/invoices/[id]/pay/page.tsx
@@ -59,32 +59,32 @@ export default function InvoicePaymentPage() {
         direction: data.direction,
         method: data.method,
       });
-      
-      toast.success("Payment recorded successfully!");
+
+      toast.success("入金が正常に登録されました！");
       router.push(`/invoices/${id}`);
     } catch (error) {
       console.error("Failed to create payment:", error);
-      toast.error("Failed to record payment. Please try again.");
+      toast.error("入金登録に失敗しました。再度お試しください。");
     }
   };
 
   if (fetchingInvoice) {
     return (
-      <div className="text-center">Loading invoice information...</div>
+      <div className="text-center">請求書情報を読み込み中...</div>
     );
   }
 
   if (invoiceError) {
     return (
       <div className="text-center text-red-500">
-        Error loading invoice: {invoiceError.message}
+        請求書の読み込みエラー: {invoiceError.message}
       </div>
     );
   }
 
   if (!invoice) {
     return (
-      <div className="text-center">Invoice not found.</div>
+      <div className="text-center">請求書が見つかりません。</div>
     );
   }
 
@@ -107,18 +107,18 @@ export default function InvoicePaymentPage() {
         {/* Invoice Information */}
         <Card>
           <CardHeader>
-            <CardTitle>Invoice Details</CardTitle>
-            <CardDescription>Information about the invoice being paid</CardDescription>
+            <CardTitle>請求書詳細</CardTitle>
+            <CardDescription>支払い対象の請求書情報</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 gap-2">
-              <div><strong>Invoice Number:</strong> {invoice.invoiceNo || invoice.id}</div>
-              <div><strong>Partner:</strong> {invoice.partnerName}</div>
-              <div><strong>Description:</strong> {invoice.description}</div>
-              <div><strong>Amount:</strong> ¥{invoice.amount?.toLocaleString()}</div>
-              <div><strong>Status:</strong> {invoice.status}</div>
-              <div><strong>Issue Date:</strong> {invoice.issueDate ? new Date(invoice.issueDate).toLocaleDateString() : ''}</div>
-              <div><strong>Due Date:</strong> {invoice.dueDate ? new Date(invoice.dueDate).toLocaleDateString() : ''}</div>
+              <div><strong>請求書番号:</strong> {invoice.invoiceNo || invoice.id}</div>
+              <div><strong>取引先:</strong> {invoice.partnerName}</div>
+              <div><strong>件名・摘要:</strong> {invoice.description}</div>
+              <div><strong>金額:</strong> ¥{invoice.amount?.toLocaleString()}</div>
+              <div><strong>ステータス:</strong> {invoice.status}</div>
+              <div><strong>発行日:</strong> {invoice.issueDate ? new Date(invoice.issueDate).toLocaleDateString() : ''}</div>
+              <div><strong>支払期限:</strong> {invoice.dueDate ? new Date(invoice.dueDate).toLocaleDateString() : ''}</div>
             </div>
           </CardContent>
         </Card>
@@ -128,9 +128,9 @@ export default function InvoicePaymentPage() {
           <CardHeader>
             <CardTitle className="flex items-center">
               <CreditCard className="mr-2 h-5 w-5" />
-              Payment Information
+              支払情報
             </CardTitle>
-            <CardDescription>Enter the payment details</CardDescription>
+            <CardDescription>支払内容を入力してください</CardDescription>
           </CardHeader>
           <CardContent>
             <Form {...form}>
@@ -140,7 +140,7 @@ export default function InvoicePaymentPage() {
                   name="amount"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Payment Amount</FormLabel>
+                      <FormLabel>支払金額</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -151,7 +151,7 @@ export default function InvoicePaymentPage() {
                         />
                       </FormControl>
                       <FormDescription>
-                        Amount being paid (can be partial or full payment)
+                        支払額（部分支払も可能）
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
@@ -163,12 +163,12 @@ export default function InvoicePaymentPage() {
                   name="paidAt"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Payment Date</FormLabel>
+                      <FormLabel>支払日</FormLabel>
                       <FormControl>
                         <Input type="date" {...field} />
                       </FormControl>
                       <FormDescription>
-                        The date when the payment was made
+                        支払を行った日付
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
@@ -180,20 +180,20 @@ export default function InvoicePaymentPage() {
                   name="direction"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Payment Direction</FormLabel>
+                      <FormLabel>入出金区分</FormLabel>
                       <Select onValueChange={field.onChange} defaultValue={field.value}>
                         <FormControl>
                           <SelectTrigger>
-                            <SelectValue placeholder="Select payment direction" />
+                            <SelectValue placeholder="区分を選択" />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          <SelectItem value="IN">Incoming (Received)</SelectItem>
-                          <SelectItem value="OUT">Outgoing (Paid)</SelectItem>
+                          <SelectItem value="IN">入金</SelectItem>
+                          <SelectItem value="OUT">出金</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormDescription>
-                        For invoices, this is typically &ldquo;Incoming&rdquo;
+                        請求書の場合は通常「入金」を選択します
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
@@ -205,21 +205,21 @@ export default function InvoicePaymentPage() {
                   name="method"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Payment Method</FormLabel>
+                      <FormLabel>支払方法</FormLabel>
                       <Select onValueChange={field.onChange} defaultValue={field.value}>
                         <FormControl>
                           <SelectTrigger>
-                            <SelectValue placeholder="Select payment method" />
+                            <SelectValue placeholder="支払方法を選択" />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          <SelectItem value="BANK">Bank Transfer</SelectItem>
-                          <SelectItem value="CASH">Cash</SelectItem>
-                          <SelectItem value="OTHER">Other</SelectItem>
+                          <SelectItem value="BANK">銀行振込</SelectItem>
+                          <SelectItem value="CASH">現金</SelectItem>
+                          <SelectItem value="OTHER">その他</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormDescription>
-                        How the payment was made
+                        支払を行った方法
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
@@ -228,14 +228,14 @@ export default function InvoicePaymentPage() {
 
                 <div className="flex gap-4">
                   <Button type="submit" className="flex-1" disabled={loading}>
-                    {loading ? "Recording..." : "Record Payment"}
+                    {loading ? "登録中..." : "支払を登録"}
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
                     onClick={() => router.push(`/invoices/${id}`)}
                   >
-                    Cancel
+                    キャンセル
                   </Button>
                 </div>
               </form>


### PR DESCRIPTION
## Summary
- translate invoice payment page to Japanese
- translate expenses pages and forms to Japanese
- show Japanese messages when listing accounts and expenses

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `web` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684304ecb7888328916707a4a8da56e0