### PR TITLE
Display forwarded user in header

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import { Bell, Settings, User, Menu } from "lucide-react"; // Added Menu
+import { Bell, User, Menu } from "lucide-react"; // Added Menu
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { useMeQuery } from "@/hooks/useMeQuery";
 
 // Define props interface
 interface HeaderProps {
@@ -18,6 +11,8 @@ interface HeaderProps {
 }
 
 export function Header({ isSidebarOpen, setIsSidebarOpen }: HeaderProps) {
+  const { user } = useMeQuery();
+  const username = user?.username ?? "";
   return (
     <header className="h-16 border-b bg-white px-4 sm:px-6 flex items-center justify-between">
       {/* Adjusted px-4 for smaller screens, sm:px-6 for slightly larger */}
@@ -40,29 +35,21 @@ export function Header({ isSidebarOpen, setIsSidebarOpen }: HeaderProps) {
         <Button variant="ghost" size="icon">
           <Bell className="h-5 w-5" />
         </Button>
-        
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="flex items-center space-x-2">
-              <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
-                <User className="h-4 w-4 text-white" />
-              </div>
-              <span className="text-sm font-medium">ユーザー</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel>アカウント</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem>
-              <Settings className="mr-2 h-4 w-4" />
-              設定
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem>
-              ログアウト
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+
+        <div className="flex items-center space-x-2">
+          <div className="w-8 h-8 rounded-full overflow-hidden bg-blue-500 flex items-center justify-center">
+            {username ? (
+              <img
+                src={`https://q.trap.jp/api/v3/public/icon/${username}`}
+                alt={username}
+                className="w-8 h-8 object-cover"
+              />
+            ) : (
+              <User className="h-4 w-4 text-white" />
+            )}
+          </div>
+          <span className="text-sm font-medium">{username || "ユーザー"}</span>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- show the current user obtained from the `Me` query in the header
- display the user's icon from `https://q.trap.jp/api/v3/public/icon/{username}`
- remove settings and logout menu from the header

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6846ffa69b9c8328bdaddf78d266e926